### PR TITLE
Made autoinstaller create missing unzip folder if it doesn't exist.

### DIFF
--- a/TeamcityArtifactAutoinstaller/App.config
+++ b/TeamcityArtifactAutoinstaller/App.config
@@ -42,6 +42,7 @@
               <InstallPath>c:\installfiles</InstallPath>
               <InstallCommand>install1.bat</InstallCommand>
               <VerifyUrl>https://project1.com/index.html</VerifyUrl>
+              <ArchiveContainsInstallCommand>false</ArchiveContainsInstallCommand>
             </TeamcityProjectConfiguration>
             <TeamcityProjectConfiguration>
               <TeamCityBaseUrl>https://myteamcirtyserver.com</TeamCityBaseUrl>
@@ -51,6 +52,7 @@
               <InstallPath>c:\installfiles</InstallPath>
               <InstallCommand>install2.bat</InstallCommand>
               <VerifyUrl>https://project2.com/index.html</VerifyUrl>
+              <ArchiveContainsInstallCommand>false</ArchiveContainsInstallCommand>
             </TeamcityProjectConfiguration>
           </ArrayOfTeamcityProjectConfiguration>
         </value>

--- a/TeamcityArtifactAutoinstaller/Properties/Settings.Designer.cs
+++ b/TeamcityArtifactAutoinstaller/Properties/Settings.Designer.cs
@@ -46,6 +46,7 @@ namespace TeamcityArtifactAutoinstaller.Properties {
               <TeamCityProjectId>project1</TeamCityProjectId>
               <InstallPath>c:\installfiles</InstallPath>
               <InstallCommand>install1.bat</InstallCommand>
+              <ArchiveContainsInstallCommand>false</ArchiveContainsInstallCommand>
             </TeamcityProjectConfiguration>
             <TeamcityProjectConfiguration>
               <TeamCityBaseUrl>https://myteamcirtyserver.com</TeamCityBaseUrl>
@@ -54,6 +55,7 @@ namespace TeamcityArtifactAutoinstaller.Properties {
               <TeamCityProjectId>project2</TeamCityProjectId>
               <InstallPath>c:\installfiles</InstallPath>
               <InstallCommand>install2.bat</InstallCommand>
+              <ArchiveContainsInstallCommand>false</ArchiveContainsInstallCommand>
             </TeamcityProjectConfiguration>
           </ArrayOfTeamcityProjectConfiguration>
         ")]

--- a/TeamcityArtifactAutoinstaller/TeamcityProjectConfiguration.cs
+++ b/TeamcityArtifactAutoinstaller/TeamcityProjectConfiguration.cs
@@ -21,5 +21,7 @@ namespace TeamcityArtifactAutoinstaller
         public string InstallCommand { get; set; }
 
         public string VerifyUrl { get; set; }
+
+        public bool ArchiveContainsInstallCommand { get; set; }
     }
 }


### PR DESCRIPTION
Added option to use install.bat inside archive and not have a separate file on server (still defaults to old behavior if setting is missing or when app.config is missing)
